### PR TITLE
Add script for counting total seen slots

### DIFF
--- a/src/count_slots.py
+++ b/src/count_slots.py
@@ -206,3 +206,20 @@ if __name__ == '__main__':
     sums = sum_slots_by_day(locations)
     for day in sums:
         print(f'{day["date"]}: {day["count"]:>9,d} (total: {day["total"]:>11,d})')
+
+    # # Break down counts by provider on each day.
+    # locations_data = {}
+    # for location in read_json_lines(location_file):
+    #     locations_data[location['id']] = location
+    
+    # days = defaultdict(lambda: defaultdict(lambda: 0))
+    # for location_id, counts in locations.items():
+    #     location_data = locations_data[location_id]
+    #     for day, count in counts.items():
+    #         days[day][location_data['provider'] or ''] += count
+
+    # for day in sorted(days.keys()):
+    #     total = sum(days[day].values())
+    #     print(f'{day}: {total:>9,d}')
+    #     for provider in sorted(days[day].keys()):
+    #         print(f'    {provider:.<32}.{days[day][provider]:.>9,d}')

--- a/src/count_slots.py
+++ b/src/count_slots.py
@@ -153,15 +153,11 @@ if __name__ == '__main__':
 
     # TODO: should this be yesterday, instead of the last date of the sequence?
     reference_date = args.reference_date or args.end_date or args.start_date
-    id_file = univaf_data.log_file_path('external_ids', reference_date)
-    location_file = univaf_data.log_file_path('provider_locations', reference_date)
-    log_files = [univaf_data.log_file_path('availability_log', dt) for dt in dates]
 
     # Download raw data files if we don't already have them locally
-    univaf_data.download_log_file('external_ids', reference_date)
-    univaf_data.download_log_file('provider_locations', reference_date)
-    for dt in dates:
-        univaf_data.download_log_file('availability_log', dt)
+    id_file = univaf_data.download_log_file('external_ids', reference_date)
+    location_file = univaf_data.download_log_file('provider_locations', reference_date)
+    log_files = [univaf_data.download_log_file('availability_log', dt) for dt in dates]
 
     # Rite Aid's API sent incorrect (and very large) numbers of slots for some
     # locations from 2021-09-09 through 2021-11-17 (when it broke). We want to

--- a/src/count_slots.py
+++ b/src/count_slots.py
@@ -163,8 +163,8 @@ if __name__ == '__main__':
 
     # TODO: should this be yesterday, instead of the last date of the sequence?
     reference_date = args.reference_date or args.end_date or args.start_date
-    id_file = data_path / f'external_ids-{reference_date}.ndjson'
-    location_file = data_path / f'provider_locations-{reference_date}.ndjson'
+    id_file = data_path / f'external_ids-{reference_date}.ndjson.gz'
+    location_file = data_path / f'provider_locations-{reference_date}.ndjson.gz'
     log_files = [data_path / f'availability_log-{dt}.ndjson.gz' for dt in dates]
 
     # FIXME: this needs to automatically download the relevant files.

--- a/src/count_slots.py
+++ b/src/count_slots.py
@@ -1,0 +1,230 @@
+# idfile = '../data/univaf_raw/external_ids-2021-10-28.ndjson'
+# locfile = '../data/univaf_raw/provider_locations-2021-10-28.ndjson'
+
+# logfiles = (
+#   '../data/univaf_raw/availability_log-2021-06-03.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-04.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-05.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-06.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-07.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-08.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-09.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-10.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-11.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-12.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-13.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-14.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-15.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-16.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-17.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-18.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-19.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-20.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-21.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-22.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-23.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-24.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-25.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-26.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-27.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-28.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-29.ndjson',
+#   '../data/univaf_raw/availability_log-2021-06-30.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-01.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-02.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-03.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-04.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-05.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-06.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-07.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-08.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-09.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-10.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-11.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-12.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-13.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-14.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-15.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-16.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-17.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-18.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-19.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-20.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-21.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-22.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-23.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-24.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-25.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-26.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-27.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-28.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-29.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-30.ndjson',
+#   '../data/univaf_raw/availability_log-2021-07-31.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-01.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-02.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-03.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-04.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-05.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-06.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-07.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-08.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-09.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-10.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-11.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-12.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-13.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-14.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-15.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-16.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-17.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-18.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-19.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-20.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-21.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-22.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-23.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-24.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-25.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-26.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-27.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-28.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-29.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-30.ndjson',
+#   '../data/univaf_raw/availability_log-2021-08-31.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-01.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-02.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-03.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-04.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-05.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-06.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-07.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-08.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-09.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-10.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-11.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-12.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-13.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-14.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-15.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-16.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-17.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-18.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-19.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-20.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-21.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-22.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-23.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-24.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-25.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-26.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-27.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-28.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-29.ndjson',
+#   '../data/univaf_raw/availability_log-2021-09-30.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-01.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-02.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-03.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-04.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-05.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-06.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-07.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-08.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-09.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-10.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-11.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-12.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-13.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-14.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-15.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-16.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-17.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-18.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-19.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-20.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-21.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-22.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-23.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-24.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-25.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-26.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-27.ndjson',
+#   '../data/univaf_raw/availability_log-2021-10-28.ndjson',
+# )
+
+import ndjson
+import json
+from collections import defaultdict
+import argparse
+import lib
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-s', '--start_date', help="first date to process")
+parser.add_argument('-e', '--end_date', help="last date to process")
+args = parser.parse_args()
+# parse dates
+dates = lib.parse_date(parser)
+
+id_file = f'../data/univaf_raw/external_ids-{dates[-1]}.ndjson'
+location_file = f'../data/univaf_raw/provider_locations-{dates[-1]}.ndjson'
+log_files = [f'../data/univaf_raw/availability_log-{dt}.ndjson' for dt in dates]
+
+
+locations = {}
+location_lookup = {}
+with open(location_file) as f:
+    reader = ndjson.reader(f)
+    for location in reader:
+        value = defaultdict(lambda: 0)
+        locations[location['id']] = value
+        location_lookup[location['id']] = value
+
+
+with open(id_file) as f:
+    reader = ndjson.reader(f)
+    for row in reader:
+        if row['system'].startswith('univaf_'):
+            # print(f"Adding merged ID: {row['value']}")
+            location = locations[row['provider_location_id']]
+            location_lookup[row['value']] = location
+
+for filepath in log_files:
+    print(f'Reading {filepath}')
+    with open(filepath) as f:
+        reader = ndjson.reader(f)
+        for row in reader:
+            location = location_lookup.get(row['location_id'])
+            if location is None:
+                print(f"WARN: no matching row for: {row['location_id']}")
+
+            capacity = row.get('capacity')
+            slots = row.get('slots')
+            if capacity:
+                for entry in capacity:
+                    # default_count = 0 if entry['available'].lower() == 'no' else 1
+                    # available_count = entry.get('available_count', default_count)
+                    # location[entry['date']] = max(location[entry['date']], available_count)
+                    name = entry['date']
+                    count = entry.get('available_count', 0) + entry.get('unavailable_count', 0)
+                    if count == 0:
+                        count = 1
+                    location[name] = max(location[name], count)
+            elif slots:
+                for entry in slots:
+                    name = entry['start'][0:10]
+                    count = entry.get('available_count', 0) + entry.get('unavailable_count', 0)
+                    if count == 0:
+                        count = 1
+                    location[name] = max(location[name], count)
+            else:
+                name = filepath[-17:-7]
+                location[name] = max(location[name], 1)
+
+total = 0
+for location_id, counts in locations.items():
+    for d, count in counts.items():
+        total += count
+
+print(f'TOTAL: {total}')
+# 436,493,577

--- a/src/count_slots.py
+++ b/src/count_slots.py
@@ -29,12 +29,12 @@ def deduplicate_locations(data, id_file):
     important because historical logs will contain reports for different
     location IDs that we later learned were duplicates.)
     """
-    clean = defaultdict(lambda: defaultdict(lambda: 0))
-
+    clean = {}
     lookup = {}
     for row in read_json_lines(id_file):
         location_id = row['provider_location_id']
         if not (location_id in lookup):
+            clean[location_id] = defaultdict(lambda: 0)
             lookup[location_id] = clean[location_id]
         if row['system'].startswith('univaf_'):
             lookup[row['value']] = clean[location_id]
@@ -43,8 +43,9 @@ def deduplicate_locations(data, id_file):
         clean_entry = lookup.get(location_id)
         if clean_entry is None:
             print(f"WARN: no matching row for: {location_id}")
-            clean_entry = clean[location_id]
+            clean_entry = defaultdict(lambda: 0)
             lookup[location_id] = clean_entry
+            clean[location_id] = clean_entry
 
         for day, count in dates.items():
             clean_entry[day] = max(clean_entry[day], count)

--- a/src/count_slots.py
+++ b/src/count_slots.py
@@ -1,9 +1,11 @@
 from collections import defaultdict
+import concurrent.futures
+import functools
 import gzip
 import json
 import os
+from pathlib import Path
 import re
-from tqdm import tqdm
 
 
 FILE_DATE_PATTERN = re.compile(r'-(\d\d\d\d-\d\d-\d\d)\.')
@@ -11,8 +13,8 @@ FILE_DATE_PATTERN = re.compile(r'-(\d\d\d\d-\d\d-\d\d)\.')
 
 def read_json_lines(filepath, compressed=None):
     if compressed is None:
-        compressed = filepath.endswith('.gz')
-    
+        compressed = str(filepath).endswith('.gz')
+
     context = gzip.open(filepath, 'rt') if compressed else open(filepath)
     with context as f:
         for line in f:
@@ -20,22 +22,34 @@ def read_json_lines(filepath, compressed=None):
                 yield json.loads(line)
 
 
-def create_location_listings(location_file, id_file):
-    locations = {}
-    location_lookup = {}
-    for location in read_json_lines(location_file):
-        value = defaultdict(lambda: 0)
-        locations[location['id']] = value
-        location_lookup[location['id']] = value
+def deduplicate_locations(data, id_file):
+    """
+    Identify duplicate locations using a recent dump of the ``external_ids``
+    table and combine slot counts from locations that are duplicates. (This is
+    important because historical logs will contain reports for different
+    location IDs that we later learned were duplicates.)
+    """
+    clean = defaultdict(lambda: defaultdict(lambda: 0))
 
-
+    lookup = {}
     for row in read_json_lines(id_file):
+        location_id = row['provider_location_id']
+        if not (location_id in lookup):
+            lookup[location_id] = clean[location_id]
         if row['system'].startswith('univaf_'):
-            # print(f"Adding merged ID: {row['value']}")
-            location = locations[row['provider_location_id']]
-            location_lookup[row['value']] = location
-    
-    return locations, location_lookup
+            lookup[row['value']] = clean[location_id]
+
+    for location_id, dates in data.items():
+        clean_entry = lookup.get(location_id)
+        if clean_entry is None:
+            print(f"WARN: no matching row for: {location_id}")
+            clean_entry = clean[location_id]
+            lookup[location_id] = clean_entry
+
+        for day, count in dates.items():
+            clean_entry[day] = max(clean_entry[day], count)
+
+    return clean
 
 
 def count_capacity_slots(entry):
@@ -46,49 +60,76 @@ def count_capacity_slots(entry):
     return count
 
 
-def count_slots_by_day_in_locations(location_lookup, log_files):
-    for filepath in log_files:
-        file_name = os.path.basename(filepath)
-        file_date = FILE_DATE_PATTERN.search(filepath).group(1)
-        lines = tqdm(read_json_lines(filepath),
-                     mininterval=2,
-                     unit='rows',
-                     unit_scale=True,
-                     desc=f'Reading {file_name}')
-        for row in lines:
-            location = location_lookup.get(row['location_id'])
-            if location is None:
-                tqdm.write(f"WARN: no matching row for: {row['location_id']}")
+def summarize_slots(records, default_date=None):
+    """
+    Given an iterable of availability log records, count the total tracked slots
+    per location and day. Returns a dict where keys are location IDs and values
+    are a dict where keys are date strings (e.g. "2021-11-01") and values are
+    integers:
 
-            capacity = row.get('capacity')
-            slots = row.get('slots')
-            if capacity:
-                for entry in capacity:
-                    day = entry['date']
-                    count = count_capacity_slots(entry)
-                    location[day] = max(location[day], count)
-                    # Be extra careful
-                    if count > 5_000:
-                        tqdm.write(f"WARN: location {row['location_id']} has {count} slots on {day}")
-            elif slots:
-                count_by_day = defaultdict(lambda: 0)
-                for entry in slots:
-                    day = entry['start'][0:10]
-                    count = count_capacity_slots(entry)
-                    count_by_day[day] += count
-                for day, count in count_by_day.items():
-                    location[day] = max(location[day], count)
-                    # Be extra careful
-                    if count > 5_000:
-                        tqdm.write(f"WARN: location {row['location_id']} has {count} slots on {day}")
-            elif 'available' in row:
-                # If there's no day- or slot-level data, be conservative and
-                # count 1 slot for the current current day of the report.
-                # ONLY do this if we actual got *some* info about availability
-                # (i.e. 'available' is filled in) -- Ignore records that
-                # represent "no change" since that data will get filled in from
-                # reading other records.
-                location[file_date] = max(location[file_date], 1)
+        {
+          'location_id': {'2021-11-01': 15, '2021-11-02': 13, ...},
+          'location_id': {'2021-11-01': 28, '2021-11-02': 10, ...},
+          ...
+        }
+    """
+    locations = defaultdict(lambda: defaultdict(lambda: 0))
+    for row in records:
+        location_id = row['location_id']
+        location = locations[location_id]
+        capacity = row.get('capacity')
+        slots = row.get('slots')
+        if capacity:
+            for entry in capacity:
+                day = entry['date']
+                count = count_capacity_slots(entry)
+                location[day] = max(location[day], count)
+                # Be extra careful
+                if count > 5_000:
+                    print(f"WARN: location {location_id} has {count} slots on {day}")
+        elif slots:
+            count_by_day = defaultdict(lambda: 0)
+            for entry in slots:
+                day = entry['start'][0:10]
+                count = count_capacity_slots(entry)
+                count_by_day[day] += count
+            for day, count in count_by_day.items():
+                location[day] = max(location[day], count)
+                # Be extra careful
+                if count > 5_000:
+                    print(f"WARN: location {location_id} has {count} slots on {day}")
+        elif 'available' in row:
+            # If there's no day- or slot-level data, be conservative and
+            # count 1 slot for the current current day of the report.
+            # ONLY do this if we actual got *some* info about availability
+            # (i.e. 'available' is filled in) -- Ignore records that
+            # represent "no change" since that data will get filled in from
+            # reading other records.
+            day = default_date or entry['valid_at'][0:10]
+            location[day] = max(location[day], 1)
+
+    return locations
+
+
+def summarize_slots_in_file(file_path, cache_directory):
+    cache_path = cache_directory / f'{file_path.name}.json'
+    if cache_path.exists():
+        print(f'Reading cache: {cache_path}...')
+        with cache_path.open(encoding='utf-8') as f:
+            return json.load(f)
+    else:
+        print(f'Reading {file_path}...')
+        file_date = FILE_DATE_PATTERN.search(file_path.name).group(1)
+        result = summarize_slots(read_json_lines(file_path), file_date)
+
+        # Cache it for later use.
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        with cache_path.open('w', encoding='utf-8') as f:
+            json.dump(result, f, separators=(',', ':'), ensure_ascii=False)
+
+        # Return a plain old dict of dicts so it's pickle-able.
+        return {location_id: dict(dates)
+                for location_id, dates in result.items()}
 
 
 def sum_slots_by_day(locations):
@@ -96,13 +137,13 @@ def sum_slots_by_day(locations):
     for counts in locations.values():
         for day, count in counts.items():
             days[day] += count
-    
+
     result = []
     total = 0
     for day in sorted(days.keys()):
         total += days[day]
         result.append({'date': day, 'count': days[day], 'total': total})
-    
+
     return result
 
 
@@ -111,13 +152,32 @@ if __name__ == '__main__':
     args = lib_cli.create_agument_parser().parse_args()
     dates = lib_cli.get_dates_in_range(args.start_date, args.end_date)
 
-    location_file = f'../data/univaf_raw/provider_locations-{dates[-1]}.ndjson'
-    id_file = f'../data/univaf_raw/external_ids-{dates[-1]}.ndjson'
-    log_files = [f'../data/univaf_raw/availability_log-{dt}.ndjson.gz' for dt in dates]
+    data_path = Path('../data/univaf_raw')
+    cache_path = Path('../data/univaf_counts')
 
-    locations, location_lookup = create_location_listings(location_file, id_file)
-    count_slots_by_day_in_locations(location_lookup, log_files)
+    # TODO: should this be yesterday, instead of the last date of the sequence?
+    id_file = data_path / f'external_ids-{dates[-1]}.ndjson'
+    log_files = [data_path / f'availability_log-{dt}.ndjson.gz' for dt in dates]
+
+    # FIXME: this needs to automatically download the relevant files.
+    
+    # Process each file, then combine the results into a dict of slot counts by
+    # day by location ID:
+    #   {
+    #     'location_id': {'2021-11-01': 15, '2021-11-02': 13, ...},
+    #     'location_id': {'2021-11-01': 28, '2021-11-02': 10, ...},
+    #     ...
+    #   }
+    locations = defaultdict(lambda: defaultdict(lambda: 0))
+    with concurrent.futures.ProcessPoolExecutor() as executor:
+        summarizer = functools.partial(summarize_slots_in_file, cache_directory=cache_path)
+        for summary in executor.map(summarizer, log_files):
+            for location_id, dates in summary.items():
+                for day, count in dates.items():
+                    locations[location_id][day] = max(locations[location_id][day], count)
+
+    locations = deduplicate_locations(locations, id_file)
 
     sums = sum_slots_by_day(locations)
     for day in sums:
-        print(f'{day["date"]}: {day["count"]:>7,d} (total: {day["total"]:>11,d})')
+        print(f'{day["date"]}: {day["count"]:>9,d} (total: {day["total"]:>11,d})')

--- a/src/count_slots.py
+++ b/src/count_slots.py
@@ -1,230 +1,123 @@
-# idfile = '../data/univaf_raw/external_ids-2021-10-28.ndjson'
-# locfile = '../data/univaf_raw/provider_locations-2021-10-28.ndjson'
-
-# logfiles = (
-#   '../data/univaf_raw/availability_log-2021-06-03.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-04.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-05.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-06.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-07.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-08.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-09.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-10.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-11.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-12.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-13.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-14.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-15.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-16.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-17.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-18.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-19.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-20.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-21.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-22.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-23.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-24.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-25.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-26.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-27.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-28.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-29.ndjson',
-#   '../data/univaf_raw/availability_log-2021-06-30.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-01.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-02.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-03.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-04.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-05.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-06.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-07.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-08.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-09.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-10.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-11.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-12.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-13.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-14.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-15.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-16.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-17.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-18.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-19.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-20.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-21.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-22.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-23.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-24.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-25.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-26.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-27.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-28.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-29.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-30.ndjson',
-#   '../data/univaf_raw/availability_log-2021-07-31.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-01.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-02.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-03.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-04.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-05.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-06.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-07.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-08.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-09.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-10.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-11.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-12.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-13.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-14.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-15.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-16.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-17.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-18.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-19.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-20.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-21.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-22.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-23.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-24.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-25.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-26.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-27.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-28.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-29.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-30.ndjson',
-#   '../data/univaf_raw/availability_log-2021-08-31.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-01.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-02.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-03.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-04.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-05.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-06.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-07.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-08.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-09.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-10.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-11.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-12.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-13.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-14.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-15.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-16.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-17.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-18.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-19.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-20.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-21.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-22.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-23.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-24.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-25.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-26.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-27.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-28.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-29.ndjson',
-#   '../data/univaf_raw/availability_log-2021-09-30.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-01.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-02.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-03.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-04.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-05.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-06.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-07.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-08.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-09.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-10.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-11.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-12.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-13.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-14.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-15.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-16.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-17.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-18.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-19.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-20.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-21.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-22.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-23.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-24.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-25.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-26.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-27.ndjson',
-#   '../data/univaf_raw/availability_log-2021-10-28.ndjson',
-# )
-
-import ndjson
-import json
 from collections import defaultdict
-import argparse
-import lib
+import gzip
+import json
+import os
+import re
+from tqdm import tqdm
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument('-s', '--start_date', help="first date to process")
-parser.add_argument('-e', '--end_date', help="last date to process")
-args = parser.parse_args()
-# parse dates
-dates = lib.parse_date(parser)
-
-id_file = f'../data/univaf_raw/external_ids-{dates[-1]}.ndjson'
-location_file = f'../data/univaf_raw/provider_locations-{dates[-1]}.ndjson'
-log_files = [f'../data/univaf_raw/availability_log-{dt}.ndjson' for dt in dates]
+FILE_DATE_PATTERN = re.compile(r'-(\d\d\d\d-\d\d-\d\d)\.')
 
 
-locations = {}
-location_lookup = {}
-with open(location_file) as f:
-    reader = ndjson.reader(f)
-    for location in reader:
+def read_json_lines(filepath, compressed=None):
+    if compressed is None:
+        compressed = filepath.endswith('.gz')
+    
+    context = gzip.open(filepath, 'rt') if compressed else open(filepath)
+    with context as f:
+        for line in f:
+            if line and line != '\n':
+                yield json.loads(line)
+
+
+def create_location_listings(location_file, id_file):
+    locations = {}
+    location_lookup = {}
+    for location in read_json_lines(location_file):
         value = defaultdict(lambda: 0)
         locations[location['id']] = value
         location_lookup[location['id']] = value
 
 
-with open(id_file) as f:
-    reader = ndjson.reader(f)
-    for row in reader:
+    for row in read_json_lines(id_file):
         if row['system'].startswith('univaf_'):
             # print(f"Adding merged ID: {row['value']}")
             location = locations[row['provider_location_id']]
             location_lookup[row['value']] = location
+    
+    return locations, location_lookup
 
-for filepath in log_files:
-    print(f'Reading {filepath}')
-    with open(filepath) as f:
-        reader = ndjson.reader(f)
-        for row in reader:
+
+def count_capacity_slots(entry):
+    count = entry.get('available_count', 0) + entry.get('unavailable_count', 0)
+    # If no counts, be conservative and assume this entry represents 1 slot.
+    if count == 0:
+        count = 1
+    return count
+
+
+def count_slots_by_day_in_locations(location_lookup, log_files):
+    for filepath in log_files:
+        file_name = os.path.basename(filepath)
+        file_date = FILE_DATE_PATTERN.search(filepath).group(1)
+        lines = tqdm(read_json_lines(filepath),
+                     mininterval=2,
+                     unit='rows',
+                     unit_scale=True,
+                     desc=f'Reading {file_name}')
+        for row in lines:
             location = location_lookup.get(row['location_id'])
             if location is None:
-                print(f"WARN: no matching row for: {row['location_id']}")
+                tqdm.write(f"WARN: no matching row for: {row['location_id']}")
 
             capacity = row.get('capacity')
             slots = row.get('slots')
             if capacity:
                 for entry in capacity:
-                    # default_count = 0 if entry['available'].lower() == 'no' else 1
-                    # available_count = entry.get('available_count', default_count)
-                    # location[entry['date']] = max(location[entry['date']], available_count)
-                    name = entry['date']
-                    count = entry.get('available_count', 0) + entry.get('unavailable_count', 0)
-                    if count == 0:
-                        count = 1
-                    location[name] = max(location[name], count)
+                    day = entry['date']
+                    count = count_capacity_slots(entry)
+                    location[day] = max(location[day], count)
+                    # Be extra careful
+                    if count > 5_000:
+                        tqdm.write(f"WARN: location {row['location_id']} has {count} slots on {day}")
             elif slots:
+                count_by_day = defaultdict(lambda: 0)
                 for entry in slots:
-                    name = entry['start'][0:10]
-                    count = entry.get('available_count', 0) + entry.get('unavailable_count', 0)
-                    if count == 0:
-                        count = 1
-                    location[name] = max(location[name], count)
-            else:
-                name = filepath[-17:-7]
-                location[name] = max(location[name], 1)
+                    day = entry['start'][0:10]
+                    count = count_capacity_slots(entry)
+                    count_by_day[day] += count
+                for day, count in count_by_day.items():
+                    location[day] = max(location[day], count)
+                    # Be extra careful
+                    if count > 5_000:
+                        tqdm.write(f"WARN: location {row['location_id']} has {count} slots on {day}")
+            elif 'available' in row:
+                # If there's no day- or slot-level data, be conservative and
+                # count 1 slot for the current current day of the report.
+                # ONLY do this if we actual got *some* info about availability
+                # (i.e. 'available' is filled in) -- Ignore records that
+                # represent "no change" since that data will get filled in from
+                # reading other records.
+                location[file_date] = max(location[file_date], 1)
 
-total = 0
-for location_id, counts in locations.items():
-    for d, count in counts.items():
-        total += count
 
-print(f'TOTAL: {total}')
-# 436,493,577
+def sum_slots_by_day(locations):
+    days = defaultdict(lambda: 0)
+    for counts in locations.values():
+        for day, count in counts.items():
+            days[day] += count
+    
+    result = []
+    total = 0
+    for day in sorted(days.keys()):
+        total += days[day]
+        result.append({'date': day, 'count': days[day], 'total': total})
+    
+    return result
+
+
+if __name__ == '__main__':
+    import lib_cli
+    args = lib_cli.create_agument_parser().parse_args()
+    dates = lib_cli.get_dates_in_range(args.start_date, args.end_date)
+
+    location_file = f'../data/univaf_raw/provider_locations-{dates[-1]}.ndjson'
+    id_file = f'../data/univaf_raw/external_ids-{dates[-1]}.ndjson'
+    log_files = [f'../data/univaf_raw/availability_log-{dt}.ndjson.gz' for dt in dates]
+
+    locations, location_lookup = create_location_listings(location_file, id_file)
+    count_slots_by_day_in_locations(location_lookup, log_files)
+
+    sums = sum_slots_by_day(locations)
+    for day in sums:
+        print(f'{day["date"]}: {day["count"]:>7,d} (total: {day["total"]:>11,d})')

--- a/src/count_slots.py
+++ b/src/count_slots.py
@@ -158,10 +158,10 @@ if __name__ == '__main__':
     log_files = [univaf_data.log_file_path('availability_log', dt) for dt in dates]
 
     # Download raw data files if we don't already have them locally
-    univaf_data.download_historical_log('external_ids', reference_date)
-    univaf_data.download_historical_log('provider_locations', reference_date)
+    univaf_data.download_log_file('external_ids', reference_date)
+    univaf_data.download_log_file('provider_locations', reference_date)
     for dt in dates:
-        univaf_data.download_historical_log('availability_log', dt)
+        univaf_data.download_log_file('availability_log', dt)
 
     # Rite Aid's API sent incorrect (and very large) numbers of slots for some
     # locations from 2021-09-09 through 2021-11-17 (when it broke). We want to

--- a/src/lib.py
+++ b/src/lib.py
@@ -180,42 +180,6 @@ def read_zipmap():
     return zipmap
 
 
-def parse_date(parser):
-    """
-    Parse date range from the command line parameters.
-    """
-    args = parser.parse_args()
-    # parse start_date
-    if args.start_date is None:
-        parser.print_help()
-        exit()
-    else:
-        try:
-            start_date = dateutil.parser.parse(args.start_date)
-        except Exception as e:
-            print("[ERROR] can't parse start_date %s, should be yyyy-mm-dd" %
-                  args.start_date)
-            exit()
-    # parse end_date
-    if args.end_date is None:
-        end_date = start_date
-    else:
-        try:
-            end_date = dateutil.parser.parse(args.end_date)
-        except Exception as e:
-            print("[ERROR] can't parse end_date %s, should be yyyy-mm-dd" %
-                  args.end_date)
-            exit()
-    # make date range
-    n = (end_date - start_date).days + 1
-    dates = [start_date + datetime.timedelta(days=x) for x in range(n)]
-    dates = sorted([x.strftime("%Y-%m-%d") for x in dates])
-    if len(dates) < 1:
-        print("[ERROR] date range has no elements")
-        exit()
-    return dates
-
-
 # inspired by https://stackoverflow.com/a/33245493
 def is_uuid(s, version=4):
     if not isinstance(s, str):

--- a/src/lib_cli.py
+++ b/src/lib_cli.py
@@ -5,7 +5,7 @@ import dateutil.parser
 
 def cli_date(text):
     """Parse a timestamp string"""
-    return dateutil.parser.parse(text)
+    return dateutil.parser.parse(text).date()
 
 
 def create_agument_parser(**kwargs):

--- a/src/lib_cli.py
+++ b/src/lib_cli.py
@@ -1,0 +1,43 @@
+import argparse
+import datetime
+import dateutil.parser
+
+
+def cli_date(text):
+    """Parse a timestamp string"""
+    return dateutil.parser.parse(text)
+
+
+def create_agument_parser(**kwargs):
+    """Create an argument parser with basic start/end date options."""
+    parser = argparse.ArgumentParser(**kwargs)
+    parser.add_argument('-s', '--start_date',
+                        help="First date to process (format: YYYY-MM-DD)",
+                        type=cli_date, metavar='DATE', required=True)
+    parser.add_argument('-e', '--end_date',
+                        help="Last date to process (format: YYYY-MM-DD)",
+                        type=cli_date, metavar='DATE')
+    return parser
+
+
+def get_dates_in_range(start_date, end_date=None):
+    """
+    Given a start and end datetime, create a list of date strings representing
+    every date between them, including the start and end dates.
+
+    Example
+    -------
+    >>> get_dates_in_range(datetime(2022, 1, 1), datetime(2022, 1, 3))
+    ['2022-01-01', '2022-01-02', '2022-01-03']
+    """
+    if end_date is None:
+        end_date = start_date
+
+    n = (end_date - start_date).days + 1
+    dates = [start_date + datetime.timedelta(days=x) for x in range(n)]
+    dates = sorted([x.strftime("%Y-%m-%d") for x in dates])
+    if len(dates) < 1:
+        print("[ERROR] date range has no elements")
+        exit()
+
+    return dates

--- a/src/process_univaf.py
+++ b/src/process_univaf.py
@@ -46,10 +46,11 @@ from glob import glob
 from shapely import wkb
 # internal
 import lib
+import univaf_data
 
 # set and make paths
-path_raw = lib.path_root + '/univaf_raw/'
-path_out = lib.path_root + '/univaf_clean/'
+path_raw = univaf_data.DATA_PATH / 'univaf_raw'
+path_out = univaf_data.DATA_PATH / 'univaf_clean'
 for path in [path_raw, path_out]:
     if not os.path.exists(path):
         os.mkdir(path)
@@ -340,19 +341,13 @@ def process_locations(path_out):
     return (locations, eid_to_id)
 
 
-def download_files(ds):
+def download_files(ds, types=None):
     """
     Download the files, if they don't already exist.
     """
-    main_url = "http://univaf-data-snapshots.s3.amazonaws.com/"
-    for type in ['availability_log', 'external_ids', 'provider_locations']:
-        url = '%s%s/%s-%s.ndjson' % (main_url, type, type, ds)
-        path_out = '%s%s-%s.ndjson' % (path_raw, type, ds)
-        if not os.path.exists(path_out):
-            print("Writing %s to %s" % (url, path_out))
-            with open(path_out, 'w') as f:
-                for line in urllib.request.urlopen(url):
-                    f.write(line.decode('utf-8'))
+    types = types or ['availability_log', 'external_ids', 'provider_locations']
+    for type in types:
+        univaf_data.download_historical_log(type, ds)
 
 
 if __name__ == "__main__":

--- a/src/process_univaf.py
+++ b/src/process_univaf.py
@@ -347,7 +347,7 @@ def download_files(ds, types=None):
     """
     types = types or ['availability_log', 'external_ids', 'provider_locations']
     for type in types:
-        univaf_data.download_historical_log(type, ds)
+        univaf_data.download_log_file(type, ds)
 
 
 if __name__ == "__main__":

--- a/src/process_univaf.py
+++ b/src/process_univaf.py
@@ -49,7 +49,7 @@ import lib
 import univaf_data
 
 # set and make paths
-path_raw = univaf_data.DATA_PATH / 'univaf_raw'
+path_raw = univaf_data.CACHE_PATH
 path_out = univaf_data.DATA_PATH / 'univaf_clean'
 for path in [path_raw, path_out]:
     if not os.path.exists(path):
@@ -84,12 +84,10 @@ def do_date(ds):
     slots = lib.read_previous_state(path_raw, ds, 'slots')
 
     # construct list of files to read
-    files = sorted(glob('%savailability_log-%s.ndjson' % (path_raw, ds)))
+    files = sorted(glob('%savailability_log-%s.ndjson.gz' % (path_raw, ds)))
     for fn in files:
-
         print("[INFO]   reading " + fn)
-        f = open(fn, 'r')
-        for row in ndjson.reader(f):
+        for row in univaf_data.read_json_lines(fn):
             try:
                 # only process rows that have a (new) valid_at field
                 if "valid_at" not in row:
@@ -205,7 +203,6 @@ def do_date(ds):
                 print("Problem data: ")
                 print(lib.pp(row))
                 exit()
-        f.close()
 
     # write unclosed records
     for iid, row in avs.items():
@@ -236,10 +233,8 @@ def process_locations(path_out):
     # read zip map
     zipmap = lib.read_zipmap()
     # read 'new' locations
-    path_loc = glob(path_raw + 'provider_locations-*.ndjson')[-1]
-    with open(path_loc, 'r') as f:
-        new_locations = ndjson.load(f)
-    for row in new_locations:
+    path_loc = glob(path_raw + 'provider_locations-*.ndjson.gz')[-1]
+    for row in univaf_data.read_json_lines(path_loc):
         # grab internal numeric id, or make one
         sid = 'uuid:%s' % row['id']
         if sid in eid_to_id:
@@ -322,11 +317,10 @@ def process_locations(path_out):
         }
 
     # read 'new' external_id to uuid mapping
-    path_ids = glob(path_raw + 'external_ids-*.ndjson')[-1]
-    with open(path_ids, 'r') as f:
-        eid_to_uuid = {}
-        for x in ndjson.load(f):
-            eid_to_uuid['%s:%s' % (x['system'], x['value'])] = x['provider_location_id']
+    eid_to_uuid = {}
+    path_ids = glob(path_raw + 'external_ids-*.ndjson.gz')[-1]
+    for x in univaf_data.read_json_lines(path_ids):
+        eid_to_uuid['%s:%s' % (x['system'], x['value'])] = x['provider_location_id']
     # insert into external_id to iid mapping
     for eid, uuid in eid_to_uuid.items():
         uuid = 'uuid:' + uuid
@@ -341,13 +335,14 @@ def process_locations(path_out):
     return (locations, eid_to_id)
 
 
-def download_files(ds, types=None):
+def download_files(dates):
     """
     Download the files, if they don't already exist.
     """
-    types = types or ['availability_log', 'external_ids', 'provider_locations']
-    for type in types:
-        univaf_data.download_log_file(type, ds)
+    univaf_data.download_log_file('provider_locations', dates[-1])
+    univaf_data.download_log_file('external_ids', dates[-1])
+    for date in dates:
+        univaf_data.download_log_file('external_ids', date)
 
 
 if __name__ == "__main__":
@@ -356,9 +351,9 @@ if __name__ == "__main__":
     dates = lib_cli.get_dates_in_range(args.start_date, args.end_date)
 
     print("[INFO] doing these dates: [%s]" % ', '.join(dates))
-    # download files
-    for date in dates:
-        download_files(date)
+    # TODO: this should return the downloaded paths and other functions should
+    # use them rather than expecting them to be in a certain place.
+    download_files(dates)
     # process latest locations file
     (locations, eid_to_id) = process_locations(path_out)
     # iterate over days

--- a/src/process_univaf.py
+++ b/src/process_univaf.py
@@ -351,13 +351,10 @@ def download_files(ds, types=None):
 
 
 if __name__ == "__main__":
-    # read arguments
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-s', '--start_date', help="first date to process")
-    parser.add_argument('-e', '--end_date', help="last date to process")
-    args = parser.parse_args()
-    # parse dates
-    dates = lib.parse_date(parser)
+    import lib_cli
+    args = lib_cli.create_agument_parser().parse_args()
+    dates = lib_cli.get_dates_in_range(args.start_date, args.end_date)
+
     print("[INFO] doing these dates: [%s]" % ', '.join(dates))
     # download files
     for date in dates:

--- a/src/process_vaccinespotter.py
+++ b/src/process_vaccinespotter.py
@@ -277,15 +277,13 @@ def download_file(fn):
 
 
 if __name__ == "__main__":
-    # read arguments
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-s', '--start_date', help="first date to process")
-    parser.add_argument('-e', '--end_date', help="last date to process")
+    import lib_cli
+    parser = lib_cli.create_agument_parser()
     parser.add_argument('-c', '--clean_run', action='store_true',
                         help="replace previous locations file")
     args = parser.parse_args()
-    # parse dates
-    dates = lib.parse_date(parser)
+    dates = lib_cli.get_dates_in_range(args.start_date, args.end_date)
+
     # compute intersection with days that VaccineSpotter actually has data for
     try:
         # first try latest, from internet (if possible)

--- a/src/requirements-min.txt
+++ b/src/requirements-min.txt
@@ -1,0 +1,10 @@
+# Minimal requirements for basic analysis. Some scripts require additional
+# packages in requirements.txt.
+# This list should try to stay compatible with PyPy.
+
+# Note: ideally, we'd install boto3[crt], but crt does not work in PyPy. :(
+boto3 ~=1.24
+python-dateutil ~=2.8
+ndjson ~=0.3
+pytz >=2021.1
+tqdm ~=4.62

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,4 @@
-python-dateutil ~=2.8
+-r requirements-min.txt
 pandas ~=1.3
-ndjson ~=0.3
-pytz >=2021.1
 us ~=2.0
 shapely ~=1.7
-tqdm ~=4.62

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,3 +4,4 @@ ndjson ~=0.3
 pytz >=2021.1
 us ~=2.0
 shapely ~=1.7
+tqdm ~=4.62

--- a/src/univaf_data.py
+++ b/src/univaf_data.py
@@ -1,0 +1,75 @@
+import gzip
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import urllib.request
+
+UNIVAF_AWS_BUCKET = 'univaf-data-snapshots'
+DATA_PATH = Path(__file__).parent.parent.absolute() / 'data'
+CACHE_PATH = DATA_PATH / 'univaf_raw'
+SUPPORTS_AWS_CLI = None
+
+
+def supports_aws_cli():
+    global SUPPORTS_AWS_CLI
+    if SUPPORTS_AWS_CLI is None:
+        result = subprocess.run(('which', 'aws'), capture_output=True)
+        SUPPORTS_AWS_CLI = result.returncode == 0
+
+    return SUPPORTS_AWS_CLI
+
+
+def s3_copy(source, destination):
+    subprocess.run(('aws', 's3', 'cp', source, destination))
+
+
+def download_file(bucket_path, destination_path, force=False):
+    if os.path.exists(destination_path) and not force:
+        return
+
+    Path(destination_path).parent.mkdir(parents=True, exist_ok=True)
+    if supports_aws_cli():
+        s3_uri = f's3://{UNIVAF_AWS_BUCKET}/{bucket_path}'
+        subprocess.run(('aws', 's3', 'cp', '--no-sign-request', s3_uri, destination_path))
+    else:
+        url = f'http://{UNIVAF_AWS_BUCKET}.s3.amazonaws.com/{bucket_path}'
+        print(f'Writing {url} to {destination_path}', file=sys.stderr)
+        with open(destination_path, 'wb') as f:
+            with urllib.request.urlopen(url) as remote:
+                f.write(remote.read())
+
+
+def log_file_name(log_type, date):
+    return f'{log_type}-{date}.ndjson.gz'
+
+
+def log_file_path(log_type, date):
+    return CACHE_PATH / log_file_name(log_type, date)
+
+
+def download_log_file(log_type, date):
+    file_name = log_file_name
+    download_file(f'{log_type}/{file_name}', CACHE_PATH / file_name)
+
+
+def open_file(filepath, compressed=None):
+    if compressed is None:
+        compressed = str(filepath).endswith('.gz')
+
+
+def read_json_lines(filepath, compressed=None):
+    with open_file(filepath, compressed) as f:
+        for line in f:
+            if line and line != '\n':
+                yield json.loads(line)
+
+
+def open_log_file(log_type, date):
+    filepath = log_file_path(log_type, date)
+    return open_file(filepath)
+
+
+def read_log_lines(log_type, date):
+    yield from read_json_lines(log_file_path(log_type, date))

--- a/src/univaf_data.py
+++ b/src/univaf_data.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 import gzip
 import json
 import os
@@ -54,9 +55,12 @@ def download_log_file(log_type, date):
     download_file(f'{log_type}/{file_name}', CACHE_PATH / file_name)
 
 
+@contextmanager
 def open_file(filepath, compressed=None):
     if compressed is None:
         compressed = str(filepath).endswith('.gz')
+    with (gzip.open(filepath, 'rt') if compressed else open(filepath)) as f:
+        yield f
 
 
 def read_json_lines(filepath, compressed=None):

--- a/src/univaf_data.py
+++ b/src/univaf_data.py
@@ -27,10 +27,11 @@ def download_file(bucket_path, destination_path, force=False):
     if os.path.exists(destination_path) and not force:
         return
 
+    print(f'Downloading logfile to: "{destination_path}"')
     Path(destination_path).parent.mkdir(parents=True, exist_ok=True)
     # Use Boto instead of normal HTTP because it has logic for multithreaded
     # downloads that makes things ~6 times faster.
-    s3_client().download_file(UNIVAF_AWS_BUCKET, bucket_path, destination_path)
+    s3_client().download_file(UNIVAF_AWS_BUCKET, bucket_path, str(destination_path))
 
 
 def log_file_name(log_type, date):

--- a/src/univaf_data.py
+++ b/src/univaf_data.py
@@ -43,7 +43,9 @@ def log_file_path(log_type, date):
 
 def download_log_file(log_type, date):
     file_name = log_file_name(log_type, date)
-    download_file(f'{log_type}/{file_name}', CACHE_PATH / file_name)
+    download_path = CACHE_PATH / file_name
+    download_file(f'{log_type}/{file_name}', download_path)
+    return download_path
 
 
 @contextmanager
@@ -59,12 +61,3 @@ def read_json_lines(filepath, compressed=None):
         for line in f:
             if line and line != '\n':
                 yield json.loads(line)
-
-
-def open_log_file(log_type, date):
-    filepath = log_file_path(log_type, date)
-    return open_file(filepath)
-
-
-def read_log_lines(log_type, date):
-    yield from read_json_lines(log_file_path(log_type, date))

--- a/src/univaf_data.py
+++ b/src/univaf_data.py
@@ -50,7 +50,7 @@ def log_file_path(log_type, date):
 
 
 def download_log_file(log_type, date):
-    file_name = log_file_name
+    file_name = log_file_name(log_type, date)
     download_file(f'{log_type}/{file_name}', CACHE_PATH / file_name)
 
 


### PR DESCRIPTION
We’ve had a few requests over time for a total count of slots that UNIVAF has monitored, so I thought I’d clean up the hacky script I originally wrote for this and add it here for later re-use. This could still use some improvement, so I’ve posted it as a draft.

This also led to some messy discoveries:
- Our data files are pretty big, and it turns out other storage formats can improve literally every aspect of this with no downsides (small files, faster to download, cheaper to store, and even faster to read and scan every line (!)). In this case, I went with batch-gzipping the current JSON files, which you can see read support for in the `read_json_lines()` function. (See a deeper analysis of all this at: usdigitalresponse/univaf#542

- I’ve never used Pypy before, but it gave us a 30-35% speed boost here! It’s doesn’t play nice with Pandas yet, though, so I wound up creating `lib_cli.py` so I could share code without tripping an `import pandas` statement.

- I switched to a more map-reduce-y pattern (summarize each log file, then combine the summaries) later, which allowed for another big speedup via parallel processing.

- The existing code uses `urllib` to download the data files from S3 using an unauthenticed HTTP request. It’s really slow (10-20 MB/s from S3 to an EC2 machine in the same region). At some point I tried using the AWS CLI client, and it downloaded data a full order of magnitude faster! Not sure if this is something special about how it forms the requests (it’s written in Python, so it’s not that) or if you just get more bandwidth when authenticated. In any case, we should take advantage of this (I haven’t included any code to do so here, though).

- Rite Aid reported bad data for slot counts from 2021-09-09 through 2021-11-17 (when their API completely broke and went offline). I added some code to “correct” for this by substituting the median slot count from the month after [we started scraping them instead](https://github.com/usdigitalresponse/univaf/issues/474) (because the API was offline), and which had more realistic & accurate data.

    *How do I know the data was bad?* Prior to the dates in question, Rite Aid had been reporting hundreds of slots/day at most for any given location. During the dates in question, it reported thousands. Further, it only ever reported one of 3 values (1,728, 1,584, or 1,440) rather than a broad spread across locations. Those three values were also the same for all locations on particular days (e.g. every location had 1,584 slots on 2021-10-06).

    *Why use 13 for the “corrected” value?* Starting a few days after the Rite Aid API went down, we started scraping their booking site, getting us a richer data set with what seems like more realistic numbers. Taking the median slots/day/location from the first month of that data seemed like good conservative replacement. However, this *does* give us 13, where the median in the week *before* the bad data, we were seeing a median of 288. It’s hard to know what’s more correct — the previous data could have been bad in different ways, could be more correct because it’s a complete count of all slots from inside their system (scraping, we only see *available* slots), could be a miscount that treats each product+slot combination as a separate slot (we almost made this mistake in our scraper), or Rite Aid could simply have changed staffing and allocation during this period and offered fewer appointment slots in late November vs. early September (after all, demand had decreased dramatically leading into this time period).


## To Do

I made this PR to get all this committed, visible, and re-usable, but it does need some further work and may not be worth merging yet.

- [x] Use nicer CLI parsing tools in other scripts.
- [x] Download with authenticaed request or AWS CLI client instead of `urllib` when credentials are available.
- [x] Actually download the necessary files instead of requring you to have done that manually (or, as I did, by hacking up `process_univaf.py`).
- [ ] Summarize data by more dimensions (maybe provider and source). Digging into the issues with Rite Aid above really highlighted how having tools for these other breakdowns would be helpful. We could build on it to automatically publish nightly reports to highlight these issues like the Rite Aid one proactively.

---

Statistics from Rite Aid, for posterity:

```
Values are numbers of slots seen on a location + day combination. These only count reports of > 1 total slots in order to filter out sources don’t provide slot- or capcity-level detail (e.g. CDC).

Misbehaving Locations: 2425 of 2471 total
Before (the week before the bad period):
  Min: 144 / Max: 432
  Mean:   254.54788260383873
  Median: 288.0
  Deciles: [144.0, 144.0, 288.0, 288.0, 288.0, 288.0, 288.0, 288.0, 288.0]
During:
  Min: 1440 / Max: 3312
  Mean:   1636.5812954028193
  Median: 1728.0
  Deciles: [1440.0, 1440.0, 1440.0, 1584.0, 1728.0, 1728.0, 1728.0, 1728.0, 1728.0]
After (the month after the bad period):
  Min: 2 / Max: 125
  Mean:   14.458970639250685
  Median: 13.0
  Deciles: [3.0, 6.0, 9.0, 11.0, 13.0, 16.0, 18.0, 22.0, 29.0]
After for locations that misbehaved:
  Min: 2 / Max: 125
  Mean:   14.444431297378738
  Median: 13
  Deciles: [3.0, 6.0, 9.0, 11.0, 13.0, 16.0, 18.0, 22.0, 29.0]
After for locations that were good:
  Min: 2 / Max: 111
  Mean:   42.815384615384616
  Median: 16
  Deciles: [2.0, 4.0, 7.0, 8.4, 16.0, 67.8, 93.0, 93.0, 96.6]
```